### PR TITLE
Completely disable specifying host type and implementation.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        framework-version: [ 'net47', 'net48', 'net6.0', 'net7.0' ]
+        framework-version: [ 'net6.0', 'net7.0' ]
 
     steps:
 

--- a/Lilikoi.Benchmarks/Mahogany/Applications/InjectSimple/SimpleInjectHost.cs
+++ b/Lilikoi.Benchmarks/Mahogany/Applications/InjectSimple/SimpleInjectHost.cs
@@ -1,7 +1,7 @@
 ﻿//       ========================
 //       Lilikoi.Benchmarks::SimpleInjectHost.cs
 //       (c) 2023. Distributed under the MIT License
-// 
+//
 // ->    Created: 22.12.2022
 // ->    Bumped: 06.02.2023
 //       ========================
@@ -22,13 +22,13 @@ public class SimpleInjectHost
 		return Injected.Execute();
 	}
 
-	public static Func<SimpleInjectHost, bool, bool> Build()
+	public static Func<bool, bool> Build()
 	{
 		return LilikoiMethod.FromMethodInfo(typeof(SimpleInjectHost).GetMethod(nameof(Execute)))
 			.Input<bool>()
 			.Output<bool>()
 			.Build()
 			.Finish()
-			.Compile<SimpleInjectHost, bool, bool>();
+			.Compile<bool, bool>();
 	}
 }

--- a/Lilikoi.Benchmarks/Mahogany/CompileBenchmarks.cs
+++ b/Lilikoi.Benchmarks/Mahogany/CompileBenchmarks.cs
@@ -1,7 +1,7 @@
 ﻿//       ========================
 //       Lilikoi.Benchmarks::CompileBenchmarks.cs
 //       (c) 2023. Distributed under the MIT License
-// 
+//
 // ->    Created: 22.12.2022
 // ->    Bumped: 06.02.2023
 //       ========================
@@ -23,7 +23,7 @@ namespace Lilikoi.Benchmarks.Mahogany;
 public class CompileBenchmarks
 {
 	[Benchmark()]
-	public Func<SimpleInjectHost, bool, bool> Simple()
+	public Func<bool, bool> Simple()
 	{
 		return SimpleInjectHost.Build();
 	}

--- a/Lilikoi.Benchmarks/Mahogany/RunBenchmarks.cs
+++ b/Lilikoi.Benchmarks/Mahogany/RunBenchmarks.cs
@@ -1,7 +1,7 @@
 ﻿//       ========================
 //       Lilikoi.Benchmarks::RunBenchmarks.cs
 //       (c) 2023. Distributed under the MIT License
-// 
+//
 // ->    Created: 22.12.2022
 // ->    Bumped: 06.02.2023
 //       ========================
@@ -25,8 +25,7 @@ namespace Lilikoi.Benchmarks.Mahogany;
 [MemoryDiagnoser(true)]
 public class RunBenchmarks
 {
-	public Func<SimpleInjectHost, bool, bool> SimpleContainer;
-	public SimpleInjectHost SimpleHost = new();
+	public Func<bool, bool> SimpleContainer;
 
 	[GlobalSetup]
 	public void Setup()
@@ -37,6 +36,6 @@ public class RunBenchmarks
 	[Benchmark()]
 	public bool Simple()
 	{
-		return SimpleContainer(SimpleHost, true);
+		return SimpleContainer(true);
 	}
 }

--- a/Lilikoi.Tests/HelloWorld/HelloWorldHost.cs
+++ b/Lilikoi.Tests/HelloWorld/HelloWorldHost.cs
@@ -1,7 +1,7 @@
 ﻿//       ========================
 //       Lilikoi.Tests::HelloWorldHost.cs
 //       (c) 2023. Distributed under the MIT License
-// 
+//
 // ->    Created: 22.12.2022
 // ->    Bumped: 06.02.2023
 //       ========================
@@ -11,7 +11,7 @@
 
 namespace Lilikoi.Tests.HelloWorld;
 
-public class HelloWorldHost
+public class HelloWorldHost : IDisposable
 {
 	[Console] public ConsoleInj ConsoleImpl;
 
@@ -20,5 +20,9 @@ public class HelloWorldHost
 		ConsoleImpl.Log("Hello!");
 
 		return ConsoleImpl;
+	}
+
+	public void Dispose()
+	{
 	}
 }

--- a/Lilikoi.Tests/HelloWorld/HelloWorldTest.cs
+++ b/Lilikoi.Tests/HelloWorld/HelloWorldTest.cs
@@ -1,7 +1,7 @@
 ﻿//       ========================
 //       Lilikoi.Tests::HelloWorldTest.cs
 //       (c) 2023. Distributed under the MIT License
-// 
+//
 // ->    Created: 22.12.2022
 // ->    Bumped: 06.02.2023
 //       ========================
@@ -34,6 +34,6 @@ public class HelloWorldTest
 
 		Console.WriteLine(build.ToString());
 
-		build.Run<HelloWorldHost, object, object>(new HelloWorldHost(), new object());
+		build.Run<object, object>(new object());
 	}
 }

--- a/Lilikoi.Tests/Injections/AllMethodsCalled/AllMethodsCalledTest.cs
+++ b/Lilikoi.Tests/Injections/AllMethodsCalled/AllMethodsCalledTest.cs
@@ -1,7 +1,7 @@
 ﻿//       ========================
 //       Lilikoi.Tests::AllMethodsCalledTest.cs
 //       (c) 2023. Distributed under the MIT License
-// 
+//
 // ->    Created: 22.12.2022
 // ->    Bumped: 06.02.2023
 //       ========================
@@ -36,7 +36,7 @@ public class AllMethodsCalledTest
 
 		Console.WriteLine(build.ToString());
 
-		build.Run<AllMethodsCalledHost, AllMethodsCalledCounter, object>(new AllMethodsCalledHost(), Instance);
+		build.Run<AllMethodsCalledCounter, object>(Instance);
 
 
 		Assert.IsTrue(Instance.InjectCalled, "Injection was not invoked");

--- a/Lilikoi.Tests/Injections/UnaccessibleProperties.cs
+++ b/Lilikoi.Tests/Injections/UnaccessibleProperties.cs
@@ -1,7 +1,7 @@
 ﻿//       ========================
 //       Lilikoi.Tests::UnaccessibleProperties.cs
 //       (c) 2023. Distributed under the MIT License
-// 
+//
 // ->    Created: 24.12.2022
 // ->    Bumped: 06.02.2023
 //       ========================
@@ -33,7 +33,7 @@ public class UnaccessibleProperties
 
 		Console.WriteLine(build.ToString());
 
-		build.Run<Host, string, string>(new Host(), "Input");
+		build.Run<string, string>( "Input");
 
 		Assert.Fail("Entry point not executed");
 	}

--- a/Lilikoi.Tests/Lilikoi.Tests.csproj
+++ b/Lilikoi.Tests/Lilikoi.Tests.csproj
@@ -12,22 +12,22 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AgileObjects.ReadableExpressions" Version="3.3.0"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0"/>
-        <PackageReference Include="NUnit" Version="3.13.3"/>
-        <PackageReference Include="NUnit3TestAdapter" Version="4.3.1"/>
-        <PackageReference Include="NUnit.Analyzers" Version="3.3.0"/>
-        <PackageReference Include="coverlet.collector" Version="3.1.2"/>
+        <PackageReference Include="AgileObjects.ReadableExpressions" Version="3.3.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
+        <PackageReference Include="NUnit" Version="3.13.3" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+        <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
+        <PackageReference Include="coverlet.collector" Version="3.1.2" />
     </ItemGroup>
 
 
     <ItemGroup>
-        <ProjectReference Include="..\Lilikoi\Lilikoi.csproj"/>
+        <ProjectReference Include="..\Lilikoi\Lilikoi.csproj" />
     </ItemGroup>
 
 
     <ItemGroup>
-        <Folder Include="Parameters"/>
+        <Folder Include="Parameters" />
     </ItemGroup>
 
 </Project>

--- a/Lilikoi.Tests/Mutator/Wildcards/WildcardTest.cs
+++ b/Lilikoi.Tests/Mutator/Wildcards/WildcardTest.cs
@@ -1,7 +1,7 @@
 ﻿//       ========================
 //       Lilikoi.Tests::WildcardTest.cs
 //       (c) 2023. Distributed under the MIT License
-// 
+//
 // ->    Created: 02.02.2023
 // ->    Bumped: 06.02.2023
 //       ========================
@@ -33,7 +33,7 @@ public class WildcardTest
 			.Finish();
 
 		var host = new WildcardHost();
-		var value = container.Run<WildcardHost, object, string>(host, host);
+		var value = container.Run<object, string>(host);
 
 		Assert.AreEqual(WILDCARD_VALUE, value);
 	}

--- a/Lilikoi.Tests/Wraps/SelfInject.cs
+++ b/Lilikoi.Tests/Wraps/SelfInject.cs
@@ -1,7 +1,7 @@
 ﻿//       ========================
 //       Lilikoi.Tests::SelfInject.cs
 //       (c) 2023. Distributed under the MIT License
-// 
+//
 // ->    Created: 24.12.2022
 // ->    Bumped: 06.02.2023
 //       ========================
@@ -34,7 +34,7 @@ public class SelfInject
 
 		Console.WriteLine(build.ToString());
 
-		var output = build.Run<Host, object, string>(new Host(), new object());
+		var output = build.Run<object, string>( new object());
 
 		Assert.Fail("Did not evaluate Assert.Pass() in WrapWithInjectionAttribute.");
 	}

--- a/Lilikoi.Tests/Wraps/WrapTests.cs
+++ b/Lilikoi.Tests/Wraps/WrapTests.cs
@@ -1,7 +1,7 @@
 ﻿//       ========================
 //       Lilikoi.Tests::WrapTests.cs
 //       (c) 2023. Distributed under the MIT License
-// 
+//
 // ->    Created: 24.12.2022
 // ->    Bumped: 06.02.2023
 //       ========================
@@ -31,7 +31,7 @@ public class WrapTests
 
 		Console.WriteLine(build.ToString());
 
-		var output = build.Run<DummyHost, object, string>(new DummyHost(), new object());
+		var output = build.Run<object, string>(new object());
 
 		Assert.AreEqual("Before", output);
 	}
@@ -50,7 +50,7 @@ public class WrapTests
 
 		Console.WriteLine(build.ToString());
 
-		var output = build.Run<DummyHost, object, string>(new DummyHost(), new object());
+		var output = build.Run<object, string>( new object());
 
 		Assert.Fail("Reached exit point without passing");
 	}
@@ -69,7 +69,7 @@ public class WrapTests
 
 		Console.WriteLine(build.ToString());
 
-		var output = build.Run<DummyHost, object, string>(new DummyHost(), new object());
+		var output = build.Run< object, string>(new object());
 
 		Assert.AreEqual("After", output);
 	}
@@ -88,7 +88,7 @@ public class WrapTests
 
 		Console.WriteLine(build.ToString());
 
-		var output = build.Run<DummyHost, string, string>(new DummyHost(), "Input");
+		var output = build.Run<string, string>("Input");
 
 		Assert.Fail("Reached exit point without passing");
 	}

--- a/Lilikoi/Compiler/Mahogany/MahoganyCompiler.cs
+++ b/Lilikoi/Compiler/Mahogany/MahoganyCompiler.cs
@@ -1,7 +1,7 @@
 ﻿//       ========================
 //       Lilikoi::MahoganyCompiler.cs
 //       (c) 2023. Distributed under the MIT License
-// 
+//
 // ->    Created: 22.12.2022
 // ->    Bumped: 06.02.2023
 //       ========================
@@ -229,6 +229,12 @@ public class MahoganyCompiler
 			var expression = mahoganyParameterStep.Generate();
 			Stack.Push(expression, Expression.Empty());
 		}
+	}
+
+	public void HostFor()
+	{
+		var step = new MahoganyCreateHostStep(Method);
+		Stack.Push(step.Generate(), Expression.Empty());
 	}
 
 	public void ParameterSafety()

--- a/Lilikoi/Compiler/Mahogany/MahoganyMethod.cs
+++ b/Lilikoi/Compiler/Mahogany/MahoganyMethod.cs
@@ -90,13 +90,13 @@ public class MahoganyMethod
 		var func = typeof(Func<,,>).MakeGenericType(Host, Input, Result);
 		var internalVariables = new[]
 		{
-			//Named(MahoganyConstants.HOST_VAR), Named(MahoganyConstants.INPUT_VAR),
+			// Named(MahoganyConstants.INPUT_VAR),
+			Named(MahoganyConstants.HOST_VAR),
 			Named(MahoganyConstants.OUTPUT_VAR)
 		};
 
 		var parameters = new[]
 		{
-			Named(MahoganyConstants.HOST_VAR),
 			Named(MahoganyConstants.INPUT_VAR)
 		};
 

--- a/Lilikoi/Compiler/Mahogany/Steps/MahoganyCreateHostStep.cs
+++ b/Lilikoi/Compiler/Mahogany/Steps/MahoganyCreateHostStep.cs
@@ -1,0 +1,33 @@
+﻿//       ========================
+//       Lilikoi::MahoganyCreateHostStep.cs
+//       (c) 2023. Distributed under the MIT License
+//
+// ->    Created: 10.08.2023
+// ->    Bumped: 10.08.2023
+//       ========================
+using System.Linq.Expressions;
+using System.Reflection;
+
+using Lilikoi.Attributes.Builders;
+
+namespace Lilikoi.Compiler.Mahogany.Steps;
+
+public class MahoganyCreateHostStep
+{
+	public MahoganyCreateHostStep(MahoganyMethod method)
+	{
+		Method = method;
+	}
+
+	public MahoganyMethod Method { get; set; }
+
+	public Expression Generate()
+	{
+		var host = Method.Named(MahoganyConstants.HOST_VAR);
+
+		var creation = Expression.New(Method.Host);
+		var assignment = Expression.Assign(host, creation);
+
+		return assignment;
+	}
+}

--- a/Lilikoi/Compiler/Public/LilikoiCompiler.cs
+++ b/Lilikoi/Compiler/Public/LilikoiCompiler.cs
@@ -1,7 +1,7 @@
 ﻿//       ========================
 //       Lilikoi::LilikoiCompiler.cs
 //       (c) 2023. Distributed under the MIT License
-// 
+//
 // ->    Created: 22.12.2022
 // ->    Bumped: 06.02.2023
 //       ========================
@@ -42,7 +42,9 @@ public class LilikoiCompiler
 	{
 		Mutators();
 
+		Internal.HostFor();
 		Internal.ParameterSafety();
+
 		Internal.InjectionsFor(Internal.Method.Host);
 
 		foreach (var implicitWrap in ImplicitWraps)

--- a/Lilikoi/Compiler/Public/LilikoiContainer.cs
+++ b/Lilikoi/Compiler/Public/LilikoiContainer.cs
@@ -1,7 +1,7 @@
 ﻿//       ========================
 //       Lilikoi::LilikoiContainer.cs
 //       (c) 2023. Distributed under the MIT License
-// 
+//
 // ->    Created: 22.12.2022
 // ->    Bumped: 06.02.2023
 //       ========================
@@ -26,16 +26,16 @@ public class LilikoiContainer : Mount
 
 	private Delegate Memoized { get; set; }
 
-	public TOut Run<THost, TIn, TOut>(THost host, TIn input)
+	public TOut Run<TIn, TOut>(TIn input)
 	{
 		if (Memoized is null)
-			Memoized = Compile<THost, TIn, TOut>();
+			Memoized = Compile<TIn, TOut>();
 
-		return (Memoized as Func<THost, TIn, TOut>)(host, input);
+		return (Memoized as Func<TIn, TOut>)(input);
 	}
 
-	public Func<THost, TIn, TOut> Compile<THost, TIn, TOut>()
+	public Func<TIn, TOut> Compile<TIn, TOut>()
 	{
-		return Body.Compile(false) as Func<THost, TIn, TOut>;
+		return Body.Compile(false) as Func<TIn, TOut>;
 	}
 }

--- a/Lilikoi/Lilikoi.csproj
+++ b/Lilikoi/Lilikoi.csproj
@@ -43,9 +43,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <None Include="..\Assets\LilikoiBox1080.png" Pack="true" PackagePath="\"/>
-        <None Include="..\LICENSE.md" Pack="true" PackagePath="\"/>
-        <None Include="..\README.md" Pack="true" PackagePath="\"/>
+        <None Include="..\Assets\LilikoiBox1080.png" Pack="true" PackagePath="\" />
+        <None Include="..\LICENSE.md" Pack="true" PackagePath="\" />
+        <None Include="..\README.md" Pack="true" PackagePath="\" />
 
     </ItemGroup>
 


### PR DESCRIPTION
Hosts should be in a completely undefined state after being used by the container, so having this extra functionality really doesn't make sense. This is a pretty big breaking change throughout the API.

Now hosts have the somewhat subtle requirement of having a parameterless injector. Adding an extra check to throw a warning before runtime might be ideal.