### PR TITLE
Enable dynamic casting of lambda result within container

### DIFF
--- a/Lilikoi.Tests/Injections/AllMethodsCalled/AllMethodsCalledHost.cs
+++ b/Lilikoi.Tests/Injections/AllMethodsCalled/AllMethodsCalledHost.cs
@@ -1,7 +1,7 @@
 ﻿//       ========================
 //       Lilikoi.Tests::AllMethodsCalledHost.cs
 //       (c) 2023. Distributed under the MIT License
-// 
+//
 // ->    Created: 22.12.2022
 // ->    Bumped: 06.02.2023
 //       ========================
@@ -11,7 +11,7 @@ public class AllMethodsCalledHost
 {
 	[AllMethodsCalled] public AllMethodsCalledInject Inject;
 
-	public object Entry(AllMethodsCalledTest.AllMethodsCalledCounter test, [AllMethodsCalledParameter] object param)
+	public string Entry(AllMethodsCalledTest.AllMethodsCalledCounter test, [AllMethodsCalledParameter] object param)
 	{
 		test.EntryCalled = true;
 
@@ -20,6 +20,6 @@ public class AllMethodsCalledHost
 		Assert.IsNotNull(Inject);
 		Assert.IsTrue(Inject.IsNotNull());
 
-		return new object();
+		return "Okay!";
 	}
 }

--- a/Lilikoi.Tests/Injections/AllMethodsCalled/AllMethodsCalledTest.cs
+++ b/Lilikoi.Tests/Injections/AllMethodsCalled/AllMethodsCalledTest.cs
@@ -36,8 +36,9 @@ public class AllMethodsCalledTest
 
 		Console.WriteLine(build.ToString());
 
-		build.Run<AllMethodsCalledCounter, object>(Instance);
+		var value = build.Run<AllMethodsCalledCounter, string>(Instance);
 
+		Assert.NotNull(value);
 
 		Assert.IsTrue(Instance.InjectCalled, "Injection was not invoked");
 		Assert.IsTrue(Instance.EntryCalled, "Entry was not invoked");

--- a/Lilikoi/Compiler/Mahogany/Generator/WrapGenerator.cs
+++ b/Lilikoi/Compiler/Mahogany/Generator/WrapGenerator.cs
@@ -1,7 +1,7 @@
 ﻿//       ========================
 //       Lilikoi::WrapGenerator.cs
 //       (c) 2023. Distributed under the MIT License
-// 
+//
 // ->    Created: 22.12.2022
 // ->    Bumped: 06.02.2023
 //       ========================
@@ -68,7 +68,8 @@ internal static class WrapGenerator
 				setter,
 				Expression.IfThen(
 					Expression.IsTrue(Expression.Field(result, WRAPRESULT_STOP)),
-					Expression.Return(method.HaltTarget, Expression.Field(result, WRAPRESULT_VALUE))
+					Expression.Return(method.HaltTarget,
+						Expression.TypeAs( Expression.Field(result, WRAPRESULT_VALUE), method.Return) )
 					));
 
 		return Expression.Block(

--- a/Lilikoi/Compiler/Mahogany/MahoganyMethod.cs
+++ b/Lilikoi/Compiler/Mahogany/MahoganyMethod.cs
@@ -105,8 +105,8 @@ public class MahoganyMethod
 		var lambdaBody = Expression.Block(
 			internalVariables,
 			Expression.Block(Temporaries.ToArray(), internalBody),
-			Expression.Return(HaltTarget, Named(MahoganyConstants.OUTPUT_VAR)),
-			Expression.Label(HaltTarget, Named(MahoganyConstants.OUTPUT_VAR))
+			Expression.Return(HaltTarget, Expression.TypeAs( Named(MahoganyConstants.OUTPUT_VAR), Return ) ),
+			Expression.Label(HaltTarget, Expression.TypeAs( Named(MahoganyConstants.OUTPUT_VAR), Return ) )
 			);
 
 		return Expression.Lambda(lambdaBody, "LilikoiContainer", parameters);

--- a/Lilikoi/Compiler/Public/LilikoiMethod.cs
+++ b/Lilikoi/Compiler/Public/LilikoiMethod.cs
@@ -48,6 +48,8 @@ public class LilikoiMethod
 		Implementation.Result = typeof(TOutput);
 		Implementation.NamedVariables.Add(MahoganyConstants.OUTPUT_VAR, Expression.Parameter(typeof(TOutput), MahoganyConstants.OUTPUT_VAR));
 
+		if (!Implementation.Result.IsAssignableFrom(Implementation.Return))
+			throw new InvalidCastException($"Cannot cast to .Output<T>() result of {typeof(TOutput).FullName} from container host return of {Implementation.Return.FullName}");
 
 		return this;
 	}


### PR DESCRIPTION
Previously, the container return and the host return had to be 1:1. Not anymore! This may introduce some subtle bad behavior however.