### PR TITLE
Change wrap validation behavior + mount API

### DIFF
--- a/Docs/attributes.md
+++ b/Docs/attributes.md
@@ -152,8 +152,9 @@ The presence of a builder attribute should do two things:
 Wraps allow you to execute before or after the entry point which modifies the input or output, or prevents the entry point
 from running altogether.
 
-> **Warning**: Wraps *do not* support property injection by default. 
->
+> [!IMPORTANT]
+> Wraps *do not* support property injection by default.
+> 
 > You can use `LilikoiInjector.Inject(mount, this)` and `LilikoiInjector.Deject(mount, this)` to emulate standard injection in the before and after methods, respectively.
 > 
 > (If you do this, it is **highly** recommended to call `Deject` at the end of your `After` function as the injections may rely on this to prevent leaks.)

--- a/Docs/containers.md
+++ b/Docs/containers.md
@@ -44,3 +44,4 @@ so that users and libraries have ways to hurl opaque data around the entry point
 4. Entry point
 5. Wrap after execution
 7. Dejection of host
+8. Casting of entry return and wrap return into container result

--- a/Docs/mounts.md
+++ b/Docs/mounts.md
@@ -15,3 +15,20 @@ The only requirement is that each entry into the mount have a unique type.
 
 Additionally, several Lilikoi Types expose a mount interface. You can add entries to a `LilikoiMutator`'s
 mount and see those entries in the finalized `LilikoiContainer`'s mount.
+
+For example, a target attribute can place metadata (or even itself!) into the LilikoiMutator
+for the creator of the Container to consume for metadata about the target. This functionality
+is used frequently in [BitMod](https://github.com/Mooshua/BitMod)
+
+## Performance
+
+Mounts are slower than normal dictionaries, but not by much.
+A mount typically takes 30-50ns to look up a single object, regardless of
+how many objects are in the mount. 
+
+Writing and checking for existance is typically
+in the 20ns range as it does not need to unbox anything.
+
+Performance for mounts is not really a big deal, as they are usually read only once
+or twice by a consuming program, compared to normal dictionaries which are constantly
+enumerated and updated.

--- a/Docs/overview.md
+++ b/Docs/overview.md
@@ -3,7 +3,7 @@
 Lilikoi is designed to replace expensive reflection logic and deliver a consistent API surface
 from the perspective of both framework and framework consumer.
 
-Lilikoi provides APIs for frameworks to define declarative helpers, such as parameter injection
+Lilikoi provides APIs for event producers to define declarative helpers, such as parameter injection
 and before/after hooks (called wraps). Additionally, users can specify arbitrary types in the
 parameters of their entry point, and Lilikoi will resolve those parameters to a wildcard injection
 if one is available.
@@ -26,7 +26,7 @@ scaffolded to replace repetitive imperative logic.
 - **Parameter** injection is for values that are *expected* to change both value and behavior between invocations,
   depending on the input value for the container.
 - **Wildcards** are similar to parameter injection, but are detected by the parameter type and not an attribute.
-  They have no explicit usage
+  They have no explicit usage, and can be assigned by the target and mutator attributes.
 
 ## Other Attributes
 
@@ -37,6 +37,10 @@ scaffolded to replace repetitive imperative logic.
 - **Mutators** allow you to hook into the Lilikoi container compiler and add your own wraps and wildcards.
   Mutators can be used to add advanced functionality to containers, and even smuggle metadata from the compilation process
   to the final container object using the provided mount interface.
+
+- **Targets** are used by the Scanner APIs to find containers within assemblies and types.
+  Targets are not required to make containers, but make the process of creating them
+  significantly easier and more consistent.
 
 ## Headless
 Lilikoi has some APIs, called "Headless" APIs, which are designed to be used without the full framework.

--- a/Lilikoi.Benchmarks/Mahogany/Applications/InjectSimple/Simple.cs
+++ b/Lilikoi.Benchmarks/Mahogany/Applications/InjectSimple/Simple.cs
@@ -1,7 +1,7 @@
 ﻿//       ========================
 //       Lilikoi.Benchmarks::Simple.cs
 //       (c) 2023. Distributed under the MIT License
-// 
+//
 // ->    Created: 22.12.2022
 // ->    Bumped: 06.02.2023
 //       ========================
@@ -27,8 +27,8 @@ public class Simple
 	}
 
 	[MethodImpl(MethodImplOptions.NoInlining)]
-	public bool Execute()
+	public object Execute()
 	{
-		return 1 == 0; // Random.Shared.Next() == Value;
+		return "Hello, World!";
 	}
 }

--- a/Lilikoi.Benchmarks/Mahogany/Applications/InjectSimple/SimpleInjectHost.cs
+++ b/Lilikoi.Benchmarks/Mahogany/Applications/InjectSimple/SimpleInjectHost.cs
@@ -8,6 +8,7 @@
 #region
 
 using Lilikoi.Compiler.Public;
+using Lilikoi.Context;
 
 #endregion
 
@@ -17,18 +18,19 @@ public class SimpleInjectHost
 {
 	[SimpleInjector] public Simple Injected;
 
-	public bool Execute()
+	public object Execute()
 	{
 		return Injected.Execute();
 	}
 
-	public static Func<bool, bool> Build()
+	public static Func<object, object> Build()
 	{
 		return LilikoiMethod.FromMethodInfo(typeof(SimpleInjectHost).GetMethod(nameof(Execute)))
-			.Input<bool>()
-			.Output<bool>()
+			.Mount(new Mount())
+			.Input<object>()
+			.Output<object>()
 			.Build()
 			.Finish()
-			.Compile<bool, bool>();
+			.Compile<object, object>();
 	}
 }

--- a/Lilikoi.Benchmarks/Mahogany/CompileBenchmarks.cs
+++ b/Lilikoi.Benchmarks/Mahogany/CompileBenchmarks.cs
@@ -23,7 +23,7 @@ namespace Lilikoi.Benchmarks.Mahogany;
 public class CompileBenchmarks
 {
 	[Benchmark()]
-	public Func<bool, bool> Simple()
+	public Func<object, object> Simple()
 	{
 		return SimpleInjectHost.Build();
 	}

--- a/Lilikoi.Benchmarks/Mahogany/RunBenchmarks.cs
+++ b/Lilikoi.Benchmarks/Mahogany/RunBenchmarks.cs
@@ -8,6 +8,7 @@
 #region
 
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
 
 using Lilikoi.Benchmarks.Mahogany.Applications.InjectSimple;
 
@@ -15,7 +16,9 @@ using Lilikoi.Benchmarks.Mahogany.Applications.InjectSimple;
 
 namespace Lilikoi.Benchmarks.Mahogany;
 
-[SimpleJob()]
+[SimpleJob(RuntimeMoniker.Net48)]
+[SimpleJob(RuntimeMoniker.Net60)]
+[SimpleJob(RuntimeMoniker.Net70)]
 [Q1Column]
 [MeanColumn]
 [MedianColumn]
@@ -25,7 +28,7 @@ namespace Lilikoi.Benchmarks.Mahogany;
 [MemoryDiagnoser(true)]
 public class RunBenchmarks
 {
-	public Func<bool, bool> SimpleContainer;
+	public Func<object, object> SimpleContainer;
 
 	[GlobalSetup]
 	public void Setup()
@@ -34,8 +37,8 @@ public class RunBenchmarks
 	}
 
 	[Benchmark()]
-	public bool Simple()
+	public object Simple()
 	{
-		return SimpleContainer(true);
+		return SimpleContainer("Hello?");
 	}
 }

--- a/Lilikoi/Attributes/Builders/LkTargetBuilderAttribute.cs
+++ b/Lilikoi/Attributes/Builders/LkTargetBuilderAttribute.cs
@@ -1,7 +1,7 @@
 ﻿//       ========================
 //       Lilikoi::LkTargetBuilderAttribute.cs
 //       (c) 2023. Distributed under the MIT License
-// 
+//
 // ->    Created: 31.01.2023
 // ->    Bumped: 06.02.2023
 //       ========================
@@ -29,5 +29,5 @@ public abstract class LkTargetBuilderAttribute : Attribute
 	/// <typeparam name="TUserContext"></typeparam>
 	/// <returns></returns>
 	public abstract bool IsTargetable<TUserContext>()
-		where TUserContext : Mount;
+		where TUserContext : IMount;
 }

--- a/Lilikoi/Attributes/LkTargetAttribute.cs
+++ b/Lilikoi/Attributes/LkTargetAttribute.cs
@@ -1,7 +1,7 @@
 ﻿//       ========================
 //       Lilikoi::LkTargetAttribute.cs
 //       (c) 2023. Distributed under the MIT License
-// 
+//
 // ->    Created: 31.01.2023
 // ->    Bumped: 06.02.2023
 //       ========================
@@ -30,7 +30,7 @@ public abstract class LkTargetAttribute : LkTargetBuilderAttribute
 	/// <typeparam name="TUserContext"></typeparam>
 	/// <returns></returns>
 	public virtual bool IsTargetedBy<TUserContext>(TUserContext context, LilikoiMutator mutator)
-		where TUserContext : Mount
+		where TUserContext : IMount
 	{
 		return true;
 	}
@@ -43,5 +43,5 @@ public abstract class LkTargetAttribute : LkTargetBuilderAttribute
 	/// <param name="mutator"></param>
 	/// <typeparam name="TUserContext"></typeparam>
 	public abstract void Target<TUserContext>(TUserContext context, LilikoiMutator mutator)
-		where TUserContext : Mount;
+		where TUserContext : IMount;
 }

--- a/Lilikoi/Collection/TypeDictionary.cs
+++ b/Lilikoi/Collection/TypeDictionary.cs
@@ -1,7 +1,7 @@
 ﻿//       ========================
 //       Lilikoi::TypeDictionary.cs
 //       (c) 2023. Distributed under the MIT License
-// 
+//
 // ->    Created: 22.12.2022
 // ->    Bumped: 06.02.2023
 //       ========================
@@ -39,9 +39,10 @@ public class TypeDictionary
 	}
 
 	public bool Has<TValue>()
-	{
-		return _underlying.ContainsKey(typeof(TValue));
-	}
+		=> Has(typeof(TValue));
+
+	public bool Has(Type t)
+		=> _underlying.ContainsKey(t);
 
 	public void Set<TValue>(TValue obj)
 	{
@@ -50,6 +51,19 @@ public class TypeDictionary
 
 		_underlying[typeof(TValue)] = obj;
 	}
+
+	public TBase? Super<TBase>(Type super)
+		where TBase: class
+	{
+		if (!typeof(TBase).IsAssignableFrom(super))
+			return null;
+
+		if (!_underlying.ContainsKey(super))
+			return null;
+
+		return _underlying[super] as TBase;
+	}
+
 
 	public void Lock(out Padlock.Key key)
 	{

--- a/Lilikoi/Compiler/Mahogany/MahoganyValidator.cs
+++ b/Lilikoi/Compiler/Mahogany/MahoganyValidator.cs
@@ -1,7 +1,7 @@
 ﻿//       ========================
 //       Lilikoi::MahoganyValidator.cs
 //       (c) 2023. Distributed under the MIT License
-// 
+//
 // ->    Created: 23.12.2022
 // ->    Bumped: 06.02.2023
 //       ========================
@@ -62,7 +62,10 @@ internal static class MahoganyValidator
 
 	internal static void ValidateWrap(LkWrapBuilderAttribute attribute, MahoganyMethod method)
 	{
-		if (!ValidWrap(attribute, method.Input, method.Result, method.Mount))
-			throw new InvalidCastException($"Wrap '{attribute.GetType().FullName}'" + $"rejected input-output pair on method '{method.Entry.Name}'");
+		if (!ValidWrap(attribute, method.Input, method.Return, method.Mount))
+			throw new InvalidCastException($"Wrap '{attribute.GetType().FullName}' " +
+			                               $"rejected input-output pair on method '{method.Entry.Name}' " +
+			                               $"with input of {method.Input.FullName} " +
+			                               $"and inner container output of {method.Return.FullName} ");
 	}
 }

--- a/Lilikoi/Compiler/Public/LilikoiCompiler.cs
+++ b/Lilikoi/Compiler/Public/LilikoiCompiler.cs
@@ -45,11 +45,11 @@ public class LilikoiCompiler
 		Internal.HostFor();
 		Internal.ParameterSafety();
 
-		Internal.InjectionsFor(Internal.Method.Host);
-
 		foreach (var implicitWrap in ImplicitWraps)
 			Internal.ImplicitWrap(implicitWrap);
 		Internal.WrapsFor();
+
+		Internal.InjectionsFor(Internal.Method.Host);
 
 		foreach (var (implicitWildcard, type) in ImplicitWildcards)
 			Internal.ImplicitWildcard(implicitWildcard, type);

--- a/Lilikoi/Compiler/Public/LilikoiMutator.cs
+++ b/Lilikoi/Compiler/Public/LilikoiMutator.cs
@@ -7,6 +7,8 @@
 //       ========================
 #region
 
+using System.Reflection;
+
 using Lilikoi.Attributes.Builders;
 using Lilikoi.Context;
 
@@ -132,4 +134,15 @@ public class LilikoiMutator : Mount
 	/// The return type of the underlying function
 	/// </summary>
 	public Type Result => Compiler.Internal.Method.Return;
+
+	/// <summary>
+	/// The entry point that the mutator is applying to
+	/// </summary>
+	public MethodInfo Method => Compiler.Internal.Method.Entry;
+
+	/// <summary>
+	/// The host that the entry point belongs to.
+	/// Note that this is the same as Method.DeclaringType
+	/// </summary>
+	public Type Host => Compiler.Internal.Method.Host;
 }

--- a/Lilikoi/Context/IMount.cs
+++ b/Lilikoi/Context/IMount.cs
@@ -1,0 +1,54 @@
+﻿//       ========================
+//       Lilikoi::IMount.cs
+//       (c) 2023. Distributed under the MIT License
+//
+// ->    Created: 13.08.2023
+// ->    Bumped: 13.08.2023
+//       ========================
+namespace Lilikoi.Context;
+
+public interface IMount
+{
+	/// <summary>
+	/// Store a single object in this mount.
+	/// The location where it is stored depends on the
+	/// generic parameter passed
+	/// </summary>
+	/// <param name="value"></param>
+	/// <typeparam name="T"></typeparam>
+	void Store<T>(T value)
+		where T : class;
+
+	/// <summary>
+	/// Get a single object, based on the generic parameter
+	/// provided.
+	/// </summary>
+	/// <typeparam name="T"></typeparam>
+	/// <returns></returns>
+	T? Get<T>()
+		where T : class;
+
+	/// <summary>
+	/// Get a subclass of a generic specified
+	/// by the passed type.
+	/// </summary>
+	/// <param name="super"></param>
+	/// <typeparam name="T"></typeparam>
+	/// <returns></returns>
+	T? Super<T>(Type super)
+		where T : class;
+
+	/// <summary>
+	/// Check if an object exists in the mount
+	/// </summary>
+	/// <typeparam name="T"></typeparam>
+	/// <returns></returns>
+	bool Has<T>();
+
+	/// <summary>
+	/// Check if an object exists in the mount
+	/// </summary>
+	/// <param name="t"></param>
+	/// <returns></returns>
+	bool Has(Type t);
+}

--- a/Lilikoi/Context/Mount.cs
+++ b/Lilikoi/Context/Mount.cs
@@ -1,7 +1,7 @@
 ﻿//       ========================
 //       Lilikoi::Mount.cs
 //       (c) 2023. Distributed under the MIT License
-// 
+//
 // ->    Created: 22.12.2022
 // ->    Bumped: 06.02.2023
 //       ========================
@@ -26,21 +26,53 @@ public class Mount
 		dictionary = other.dictionary;
 	}
 
+	/// <summary>
+	/// Store a single object in this mount.
+	/// The location where it is stored depends on the
+	/// generic parameter passed
+	/// </summary>
+	/// <param name="value"></param>
+	/// <typeparam name="T"></typeparam>
 	public virtual void Store<T>(T value)
 		where T : class
-	{
-		dictionary.Set(value);
-	}
+		=> dictionary.Set(value);
 
+
+	/// <summary>
+	/// Get a single object, based on the generic parameter
+	/// provided.
+	/// </summary>
+	/// <typeparam name="T"></typeparam>
+	/// <returns></returns>
 	public virtual T? Get<T>()
 		where T : class
+		=> dictionary.Get<T>();
 
-	{
-		return dictionary.Get<T>();
-	}
 
+	/// <summary>
+	/// Get a subclass of a generic specified
+	/// by the passed type.
+	/// </summary>
+	/// <param name="super"></param>
+	/// <typeparam name="T"></typeparam>
+	/// <returns></returns>
+	public virtual T? Super<T>(Type super) where T : class
+		=> dictionary.Super<T>(super);
+
+	/// <summary>
+	/// Check if an object exists in the mount
+	/// </summary>
+	/// <typeparam name="T"></typeparam>
+	/// <returns></returns>
 	public virtual bool Has<T>()
-	{
-		return dictionary.Has<T>();
-	}
+		=> dictionary.Has<T>();
+
+	/// <summary>
+	/// Check if an object exists in the mount
+	/// </summary>
+	/// <param name="t"></param>
+	/// <returns></returns>
+	public virtual bool Has(Type t)
+		=> dictionary.Has(t);
+
 }

--- a/Lilikoi/Context/Mount.cs
+++ b/Lilikoi/Context/Mount.cs
@@ -13,7 +13,7 @@ using Lilikoi.Collection;
 
 namespace Lilikoi.Context;
 
-public class Mount
+public class Mount : IMount
 {
 	private TypeDictionary dictionary = new();
 
@@ -26,52 +26,27 @@ public class Mount
 		dictionary = other.dictionary;
 	}
 
-	/// <summary>
-	/// Store a single object in this mount.
-	/// The location where it is stored depends on the
-	/// generic parameter passed
-	/// </summary>
-	/// <param name="value"></param>
-	/// <typeparam name="T"></typeparam>
+	/// <inheritdoc />
 	public virtual void Store<T>(T value)
 		where T : class
 		=> dictionary.Set(value);
 
 
-	/// <summary>
-	/// Get a single object, based on the generic parameter
-	/// provided.
-	/// </summary>
-	/// <typeparam name="T"></typeparam>
-	/// <returns></returns>
+	/// <inheritdoc />
 	public virtual T? Get<T>()
 		where T : class
 		=> dictionary.Get<T>();
 
 
-	/// <summary>
-	/// Get a subclass of a generic specified
-	/// by the passed type.
-	/// </summary>
-	/// <param name="super"></param>
-	/// <typeparam name="T"></typeparam>
-	/// <returns></returns>
+	/// <inheritdoc />
 	public virtual T? Super<T>(Type super) where T : class
 		=> dictionary.Super<T>(super);
 
-	/// <summary>
-	/// Check if an object exists in the mount
-	/// </summary>
-	/// <typeparam name="T"></typeparam>
-	/// <returns></returns>
+	/// <inheritdoc />
 	public virtual bool Has<T>()
 		=> dictionary.Has<T>();
 
-	/// <summary>
-	/// Check if an object exists in the mount
-	/// </summary>
-	/// <param name="t"></param>
-	/// <returns></returns>
+	/// <inheritdoc />
 	public virtual bool Has(Type t)
 		=> dictionary.Has(t);
 

--- a/Lilikoi/Scan/Scanner.cs
+++ b/Lilikoi/Scan/Scanner.cs
@@ -31,7 +31,7 @@ public static class Scanner
 	/// <typeparam name="TOutput"></typeparam>
 	/// <returns></returns>
 	public static List<LilikoiContainer> Scan<TUserContext, TInput, TOutput>(TUserContext context, Assembly assembly, Mount mount)
-		where TUserContext : Mount
+		where TUserContext : IMount
 	{
 		return Scan<TUserContext, TInput, TOutput>(context, assembly, () => mount);
 	}
@@ -48,7 +48,7 @@ public static class Scanner
 	/// <typeparam name="TOutput"></typeparam>
 	/// <returns></returns>
 	public static List<LilikoiContainer> Scan<TUserContext, TInput, TOutput>(TUserContext context, Assembly assembly, Func<Mount> sourceMount)
-		where TUserContext : Mount
+		where TUserContext : IMount
 	{
 		List<LilikoiContainer> containers = new();
 
@@ -70,11 +70,11 @@ public static class Scanner
 	/// <typeparam name="TType"></typeparam>
 	/// <returns></returns>
 	public static List<LilikoiContainer> Scan<TUserContext, TInput, TOutput, TType>(TUserContext context, Func<Mount> sourceMount)
-		where TUserContext : Mount
+		where TUserContext : IMount
 		=> Scan<TUserContext, TInput, TOutput>(context, typeof(TType), sourceMount);
 
 	public static List<LilikoiContainer> Scan<TUserContext, TInput, TOutput>(TUserContext context, Type type, Func<Mount> sourceMount)
-		where TUserContext : Mount
+		where TUserContext : IMount
 	{
 		List<LilikoiContainer> containers = new();
 
@@ -96,7 +96,7 @@ public static class Scanner
 	/// <typeparam name="TOutput"></typeparam>
 	/// <returns></returns>
 	public static List<LilikoiContainer> Scan<TUserContext, TInput, TOutput>(TUserContext context, MethodInfo methodInfo, Func<Mount> sourceMount)
-		where TUserContext : Mount
+		where TUserContext : IMount
 	{
 		List<LilikoiContainer> containers = new();
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,12 @@
 |------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Dev  | [![dev](https://github.com/Mooshua/Lilikoi/actions/workflows/tests.yml/badge.svg?branch=dev)](https://github.com/Mooshua/Lilikoi/actions/workflows/tests.yml)   |
 
-> **Warning**: Lilikoi is in active, early development and should not be used unless you accept the
+> [!WARNING]
+> Lilikoi is in active, early development and should not be used unless you accept the
 > risk that everything may change or break.
 
-> **Note**: Lilikoi requires the .NET 7 SDK in order to be compiled, but can be used (and is tested
+> [!NOTE]
+> Lilikoi requires the .NET 7 SDK in order to be compiled, but can be used (and is tested
 > on) on any .NET Standard 2.0 platform.
 
 ### Status
@@ -21,14 +23,14 @@
 | Parameter Injection | ️️✔️   |
 | Hooks ("Wraps")     | ✔️     |
 | Contexts ("Mounts") | ✔️     |
-| Builder Attributes  | 🏗️    |
+| Builder Attributes  | ✔️    |
 | Configuration       | 🏗️    |
 | Headless/Portable   | 🏗️    |
 | Wildcards           | ✔️     |
 | Ecosystem           | ⏳      |
 | Async/Await         | ⏳      |
 | Debugging           | ⏳      |
-| NuGet Release       | 🏗️    |
+| NuGet Release       | ✔️    |
 
 ### Documentation
 
@@ -41,7 +43,7 @@ Documentation is a work in progress, but here's what we have so far:
 
 ### What is it?
 
-Lilikoi is a *framework for frameworks*.
+Lilikoi is a *framework for event handlers*.
 It defines a common ground for dependency injection and pre/post behavior.
 This allows programmers to write framework agnostic code that runs anywhere Lilikoi runs.
 
@@ -51,7 +53,8 @@ Using C# reflection APIs, a method is created which injects values into an insta
 class and then executes the entry point.
 
 ```cs
-public class SampleInjectionAttribute : MkTypedInjectionAttribute<SampleClass>
+//  An attribute which injects a new SampleClass into the container
+public class SampleInjectionAttribute : LkTypedInjectionAttribute<SampleClass>
 {
 	public override SampleClass Inject()
 	{
@@ -61,18 +64,63 @@ public class SampleInjectionAttribute : MkTypedInjectionAttribute<SampleClass>
 ```
 
 ```cs
-class Program
+//  The host of the container
+class Host
 {
     [SampleInjection]
-    public SampleClass InjectedClass;
+    private SampleClass _injectedClass;
   
-    //  Entry point
+    //  The entry point of the container
     public Task Entry()
     {
-        InjectedClass.DoSomething();
+        _injectedClass.DoSomething();
     }
 }
 ```
+
+### What is it good for?
+
+Lilikoi acts as a glue layer between event producers and event handlers.
+
+Lilikoi automates discovery of event handlers and creating an API surface
+that an event producer can easily consume. Lilikoi also generates the API surface
+expected by the handler at runtime--so both sides of the event handler can use the contracts
+they expect.
+
+Lilikoi is used in my project [BitMod](https://github.com/Mooshua/BitMod), where it
+glues plugins together with event handlers:
+
+```cs
+public class WhitelistHooks
+{
+	[Config("whitelist")]
+	private WhitelistFile _whitelist;
+
+	[BitHook(Priority.LOW)]
+	private async Task<Directive> ServerConnectionRequest(GameServerConnectingEventArgs ev)
+	{
+		foreach (IPAddress allowedConnection in _whitelist.Parse(_logger))
+		{
+			if (allowedConnection.GetAddressBytes().SequenceEqual(ev.IPAddress.GetAddressBytes()))
+			    return Directive.Allow;
+		}
+		return Directive.Neutral;
+	}
+}
+```
+
+Other plugins and BitMod can then invoke these handlers with a gloriously simple API.
+The `BitHook` type places a `RouterAssignments` object in the container during compilation,
+which is consumed by BitMod to find containers that handle the same event and group them together.
+All in all, it looks like this:
+
+```cs
+public override async Task<bool> OnGameServerConnecting(IPAddress arg)
+    => _invoker.Hook(new GameServerConnectingEventArgs(arg), defaultValue: false);
+```
+
+Overall, Lilikoi can be used in almost all event-handler use cases to provide
+consistent and understandable APIs to both the event producer and the consumer.
 
 ### Headless
 
@@ -90,59 +138,13 @@ expression trees**,
 which behave just like a normal method.
 
 Expression trees are no golden ticket to performanceville,
-but proper runtime code generation makes Lilikoi's overhead as low as **40ns** per injection
+but proper runtime code generation makes Lilikoi's overhead as low as **60ns** per injection
 
 | Framework      | Task              | Speed    |
 |:---------------|:------------------|----------|
-| .NET CLR       | Inject            | 45 ns    |
+| .NET CLR       | Inject            | 60 ns    |
 | .NET CLR       | Inject *(Debug)*  | 325 ns   |
-| .NET Framework | Inject            | 65 ns    |
+| .NET Framework | Inject            | 100 ns   |
 | .NET CLR       | Compile           | 0.330 ms |
 | .NET CLR       | Compile *(Debug)* | 0.015 ms |
 | .NET Framework | Compile           | 0.460 ms |
-
-### What could finished Lilikoi look like?
-
-Lilikoi could be used in any framework which heavily uses event-based programming,
-such as games (or game mods!), discord bots, HTTP servers (ASP.NET),
-RPC servers, automation tools, and more.
-
-A finished version of Lilikoi could look like this from the standpoint of an application developer:
-
-```cs
-[Controller("/users")]
-public class ApiController
-{
-    /// DbContext is instantiated by a generic new() injector attribute
-    /// EF Core will take care of the rest.
-    [New]
-    public ApiContext Db;
-    
-    /// You can imagine anything to go here--Because anything can!
-    /// Lilikoi should be customizable to your heart's content.
-    /// No more arbitrary framework restrictions!
-    [ApiService]
-    public UserService Users;
-
-    /// POSTAttribute is a "builder" attribute
-    /// with a method (similar to Inject()) that describes how to build the container to Lilikoi.
-    /// A HTTP server could use this to gather a list of routes and Lilikoi containers associated with them!
-    [POST("/message")]
-    /// BodyAttribute is a "wrap" attribute
-    /// which defines methods to be executed before or after the entry point (in this case, parsing the body)
-    [Body(BodyType.Json)]
-    /// You can define your own application code here to authenticate and authorize the users.
-    [Authenticate(UserType.Commenter)]
-    /// FromBodyAttribute is a "parameter inject" attribute
-    /// which accepts a context ("mount") from the wraps and builder attributes to provide additional parameters and abstractions.
-    public Response PostMessage([JsonBody] PostMessageRequest request)
-    {
-        var success = Users.NewMessage(request.ToMessage());
-        
-        if (success)
-          return Response.Success();
-          
-        return Response.Error();
-    }
-}
-```


### PR DESCRIPTION
This allows wraps to work in more locations, as they no longer have to conform to the
outer container result and can take advantage of the inner container's new flexibility