### PR TITLE
Add support for removing a mounted type

### DIFF
--- a/Lilikoi/Collection/TypeDictionary.cs
+++ b/Lilikoi/Collection/TypeDictionary.cs
@@ -51,6 +51,22 @@ public class TypeDictionary
 
 		_underlying[typeof(TValue)] = obj;
 	}
+	
+	public void Remove<TValue>(TValue obj)
+	{
+		if (mutable.IsLocked())
+			throw new Exception("Locked.");
+
+		_underlying[typeof(TValue)] = null!;
+	}
+	
+	public void Remove(Type t)
+	{
+		if (mutable.IsLocked())
+			throw new Exception("Locked.");
+
+		_underlying[t] = null!;
+	}
 
 	public TBase? Super<TBase>(Type super)
 		where TBase: class
@@ -63,6 +79,7 @@ public class TypeDictionary
 
 		return _underlying[super] as TBase;
 	}
+	
 
 
 	public void Lock(out Padlock.Key key)

--- a/Lilikoi/Collection/TypeDictionary.cs
+++ b/Lilikoi/Collection/TypeDictionary.cs
@@ -57,15 +57,15 @@ public class TypeDictionary
 		if (mutable.IsLocked())
 			throw new Exception("Locked.");
 
-		_underlying[typeof(TValue)] = null!;
+		_underlying.Remove(typeof(TValue));
 	}
 	
-	public void Remove(Type t)
+	public void Remove(Type type)
 	{
 		if (mutable.IsLocked())
 			throw new Exception("Locked.");
 
-		_underlying[t] = null!;
+		_underlying.Remove(type);
 	}
 
 	public TBase? Super<TBase>(Type super)

--- a/Lilikoi/Context/IMount.cs
+++ b/Lilikoi/Context/IMount.cs
@@ -39,6 +39,20 @@ public interface IMount
 		where T : class;
 
 	/// <summary>
+	/// Remove the object referred to by typeof(T)
+	/// </summary>
+	/// <param name="value"></param>
+	/// <typeparam name="T"></typeparam>
+	void Remove<T>(T value)
+		where T : class;
+
+	/// <summary>
+	/// Remove the object referred to by T
+	/// </summary>
+	/// <param name="type"></param>
+	void Remove(Type type);
+
+	/// <summary>
 	/// Check if an object exists in the mount
 	/// </summary>
 	/// <typeparam name="T"></typeparam>

--- a/Lilikoi/Context/Mount.cs
+++ b/Lilikoi/Context/Mount.cs
@@ -31,7 +31,18 @@ public class Mount : IMount
 		where T : class
 		=> dictionary.Set(value);
 
+	
+	/// <inheritdoc />
+	public virtual void Remove<T>(T value)
+		where T : class
+		=> dictionary.Remove(value);
+	
+	
+	/// <inheritdoc />
+	public virtual void Remove(Type type)
+		=> dictionary.Remove(type);
 
+	
 	/// <inheritdoc />
 	public virtual T? Get<T>()
 		where T : class


### PR DESCRIPTION
To better match the lifestyle pattern, I think this should be supported:
```cs

public class SampleExtension : IExtension
{
    
    public string Name => "Sample";

    private readonly ISomethingService _somethingService;

    public SampleExtension(ISomethingService somethingService)
    {
        _somethingService = somethingService ?? throw new ArgumentNullException(nameof(somethingService));
    }

    public void Register(Mount mount)
    {
        // Add services required by SampleExtension
        mount.Store(_somethingService);
    }

    public void Unregister(Mount mount)
    {
        // Remove services required by SampleExtension
        mount.Remove(_somethingService);
    }
}
```